### PR TITLE
better filtering diffing dirs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,14 @@ async function run() {
     head: actions.payload.pull_request!["head"]["sha"]
   });
   const baseRef = actions.payload.pull_request!["base"]["ref"];
-  const detectedDirs = Array.from(new Set((compareData.data.files || [])
-    .filter(file => file.status === 'modified' || file.status === 'changed')
-    .filter(file => file.filename.startsWith('deploy/'))
-    .map(file => path.dirname(file.filename))));
+  const detectedDirs = Array.from(
+    new Set(
+      (compareData.data.files || [])
+        .filter(file => file.status === 'modified' || file.status === 'changed')
+        .filter(file => file.filename.endsWith('kustomization.yaml'))
+        .map(file => path.dirname(file.filename))
+    )
+  );
 
   for (let detectedDir of detectedDirs) {
     core.info(`Compare differences between Kustomization build output in "${detectedDir}".`);


### PR DESCRIPTION
`deploy/`로 가르는거보다는 우리목표가 `kustomize` diff를 비교하는데 있는거라는 점에서 `kustomization.yaml` diff로 filtering하는게 나을거 같은데 어떻게 생각하시나요
