### PR TITLE
feat: Remove downloaded charts to re-pull a chart of the different version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13667,6 +13667,7 @@ function run() {
                 continue;
             }
             yield exec.exec(`git checkout ${actions.payload.pull_request["head"]["ref"]}`);
+            yield fs_1.promises.rm(`${detectedDir}/charts`, { recursive: true, force: true });
             const currKustomizationOutput = yield exec.getExecOutput(`./kubectl kustomize --enable-helm ${detectedDir}`, undefined, { silent: true, ignoreReturnCode: true });
             if (currKustomizationOutput.exitCode === 0) {
                 yield fs_1.promises.writeFile("/tmp/kustomization-results/2.yaml", currKustomizationOutput.stdout);

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ async function run() {
       continue;
     }
     await exec.exec(`git checkout ${actions.payload.pull_request!["head"]["ref"]}`);
+    await fs.rm(`${detectedDir}/charts`, { recursive: true, force: true });
 
     const currKustomizationOutput = await exec.getExecOutput(
       `./kubectl kustomize --enable-helm ${detectedDir}`,


### PR DESCRIPTION
chart version이 변경되는 경우 checkout 후 kustomize build를 할 때 chart를 다시 pull하도록 하기 위하여 charts/ 폴더를 비워줘야 합니다.